### PR TITLE
Add a reject target to send things to the bit bucket

### DIFF
--- a/server.py
+++ b/server.py
@@ -8,6 +8,7 @@
 import base64
 import os
 import re
+import io
 import struct
 import socket
 import logging
@@ -101,6 +102,18 @@ class Connector:
     def __str__(self):
         return '%s(netloc=%s, path=%s)' % (self.__class__.__name__, repr(self.netloc), repr(self.path))
 
+class RejectConnector(Connector):
+    @classmethod
+    def accept(cls, scheme):
+        return scheme == 'reject'
+
+    def connect(self, host, port, callback):
+        rejectmsg = io.BytesIO()
+        def reject_request(req_callback,chunk_callback):
+            req_callback(b'HTTP/1.1 410 Gone\r\n\r\n')
+            req_callback(b'')
+        rejectmsg.read_until_close = reject_request
+        callback(rejectmsg)
 
 class DirectConnector(Connector):
 

--- a/server.py
+++ b/server.py
@@ -13,7 +13,6 @@ import socket
 import logging
 import tornado.ioloop
 import tornado.netutil
-import io
 from urllib.parse import urlparse, urlunparse
 from collections import OrderedDict
 
@@ -102,19 +101,6 @@ class Connector:
     def __str__(self):
         return '%s(netloc=%s, path=%s)' % (self.__class__.__name__, repr(self.netloc), repr(self.path))
 
-class RejectConnector(Connector):
-    @classmethod
-    def accept(cls, scheme):
-        return scheme == 'reject'
-
-    def connect(self, host, port, callback):
-        ios = io.BytesIO()
-        def returnnow(a,b):
-            a(b'HTTP/1.1 410 Gone\r\n\r\n')
-            a(b'')
-            return
-        ios.read_until_close = returnnow
-        callback(ios)
 
 class DirectConnector(Connector):
 
@@ -280,7 +266,7 @@ class ProxyHandler:
 
     def on_connect_connected(self, outgoing):
         if outgoing:
-            self.incoming.write(b'HTTP/1.1 200 Connection Established\r\n\r\n')
+            self.incoming.write(b'HTTP/1.0 200 Connection Established\r\n\r\n')
             pipe(self.incoming, outgoing)
         else:
             self.incoming.close()

--- a/server.py
+++ b/server.py
@@ -266,7 +266,7 @@ class ProxyHandler:
 
     def on_connect_connected(self, outgoing):
         if outgoing:
-            self.incoming.write(b'HTTP/1.0 200 Connection Established\r\n\r\n')
+            self.incoming.write(b'HTTP/1.1 200 Connection Established\r\n\r\n')
             pipe(self.incoming, outgoing)
         else:
             self.incoming.close()

--- a/server.py
+++ b/server.py
@@ -46,7 +46,13 @@ def netloc_parser(netloc, default_port = -1):
 def write_to(stream):
     def on_data(data):
         if data == b'':
-            stream.close()
+            #print('stream.close')
+            try:
+                stream.nullreads+=1
+            except:
+                stream.nullreads=1
+            if stream.nullreads==4:
+                stream.close()
         else:
             if not stream.closed():
                 stream.write(data)


### PR DESCRIPTION
This adds a reject target such that a rule can just reject requests, can drop ads or other annoying things.  

I also added a simple version string that makes it possible for the osx version of microsoft outlook work.
