### PR TITLE
Display the real listening host and port

### DIFF
--- a/server.py
+++ b/server.py
@@ -353,7 +353,7 @@ def main():
     logging.info('using connector: %s', connector)
     host, port = hostport_parser(args.bind, 8000)
     server = ProxyServer(connector)
-    logging.info('listening on %s', port)
+    logging.info('listening on %s:%s', host, port)
     server.listen(port, host)
 
     tornado.ioloop.IOLoop.instance().start()

--- a/server.py
+++ b/server.py
@@ -353,7 +353,7 @@ def main():
     logging.info('using connector: %s', connector)
     host, port = hostport_parser(args.bind, 8000)
     server = ProxyServer(connector)
-    logging.info('listening on %s', args.bind)
+    logging.info('listening on %s', port)
     server.listen(port, host)
 
     tornado.ioloop.IOLoop.instance().start()


### PR DESCRIPTION
Display the host and port in the configuration may confuse users.
And have you considered to split it into two options?
