### PR TITLE
write protection

### DIFF
--- a/server.py
+++ b/server.py
@@ -218,13 +218,14 @@ class RulesConnector(Connector):
 
     def __init__(self, netloc=None, path=None):
         Connector.__init__(self, netloc, path)
-        self.rules = []
+        self.rules = None
         self._connectors = {}
         self._modify_time = None
         self.check_update()
         tornado.ioloop.PeriodicCallback(self.check_update, 1000).start()
 
     def load_rules(self):
+        self.rules = []
         with open(self.path) as f:
             for l in f:
                 l = l.strip()


### PR DESCRIPTION
add protection on write operation.

below is some error log:

ERROR:tornado.application:Uncaught exception, closing connection.
Traceback (most recent call last):
  File "/usr/local/lib/python3.4/site-packages/tornado/iostream.py", line 354, in wrapper
    callback(_args)
  File "/usr/local/lib/python3.4/site-packages/tornado/stack_context.py", line 331, in wrapped
    raise_exc_info(exc)
  File "<string>", line 3, in raise_exc_info
  File "/usr/local/lib/python3.4/site-packages/tornado/stack_context.py", line 302, in wrapped
    ret = fn(_args, *_kwargs)
  File "./server.py", line 135, in on_connected
    callback(stream)
  File "./server.py", line 305, in on_connect_connected
    self.incoming.write(b'HTTP/1.1 200 Connection Established\r\n\r\n')
  File "/usr/local/lib/python3.4/site-packages/tornado/iostream.py", line 214, in write
    self._check_closed()
  File "/usr/local/lib/python3.4/site-packages/tornado/iostream.py", line 593, in _check_closed
    raise StreamClosedError("Stream is closed")
tornado.iostream.StreamClosedError: Stream is closed
ERROR:tornado.application:Exception in callback functools.partial(<function wrap.<locals>.wrapped at 0x10867f598>)
Traceback (most recent call last):
  File "/usr/local/lib/python3.4/site-packages/tornado/ioloop.py", line 477, in _run_callback
    callback()
  File "/usr/local/lib/python3.4/site-packages/tornado/stack_context.py", line 331, in wrapped
    raise_exc_info(exc)
  File "<string>", line 3, in raise_exc_info
  File "/usr/local/lib/python3.4/site-packages/tornado/stack_context.py", line 302, in wrapped
    ret = fn(_args, *_kwargs)
  File "/usr/local/lib/python3.4/site-packages/tornado/iostream.py", line 354, in wrapper
    callback(_args)
  File "/usr/local/lib/python3.4/site-packages/tornado/stack_context.py", line 331, in wrapped
    raise_exc_info(exc)
  File "<string>", line 3, in raise_exc_info
  File "/usr/local/lib/python3.4/site-packages/tornado/stack_context.py", line 302, in wrapped
    ret = fn(_args, *_kwargs)
  File "./server.py", line 135, in on_connected
    callback(stream)
  File "./server.py", line 305, in on_connect_connected
    self.incoming.write(b'HTTP/1.1 200 Connection Established\r\n\r\n')
  File "/usr/local/lib/python3.4/site-packages/tornado/iostream.py", line 214, in write
    self._check_closed()
  File "/usr/local/lib/python3.4/site-packages/tornado/iostream.py", line 593, in _check_closed
    raise StreamClosedError("Stream is closed")
tornado.iostream.StreamClosedError: Stream is closed
